### PR TITLE
Supporting json.Marshaler/Unmarshaler

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -55,6 +55,71 @@ func NewDecoder(r io.Reader) *Decoder {
 }
 
 // Unmarshal reads v from the given Velocypack encoded data slice.
+//
+// Unmarshal uses the inverse of the encodings that
+// Marshal uses, allocating maps, slices, and pointers as necessary,
+// with the following additional rules:
+//
+// To unmarshal VelocyPack into a pointer, Unmarshal first handles the case of
+// the VelocyPack being the VelocyPack literal Null. In that case, Unmarshal sets
+// the pointer to nil. Otherwise, Unmarshal unmarshals the VelocyPack into
+// the value pointed at by the pointer. If the pointer is nil, Unmarshal
+// allocates a new value for it to point to.
+//
+// To unmarshal VelocyPack into a value implementing the Unmarshaler interface,
+// Unmarshal calls that value's UnmarshalVPack method, including
+// when the input is a VelocyPack Null.
+// Otherwise, if the value implements encoding.TextUnmarshaler
+// and the input is a VelocyPack quoted string, Unmarshal calls that value's
+// UnmarshalText method with the unquoted form of the string.
+//
+// To unmarshal VelocyPack into a struct, Unmarshal matches incoming object
+// keys to the keys used by Marshal (either the struct field name or its tag),
+// preferring an exact match but also accepting a case-insensitive match.
+// Unmarshal will only set exported fields of the struct.
+//
+// To unmarshal VelocyPack into an interface value,
+// Unmarshal stores one of these in the interface value:
+//
+//	bool, for VelocyPack Bool's
+//	float64 for VelocyPack Double's
+//  uint64 for VelocyPack UInt's
+//  int64 for VelocyPack Int's
+//	string, for VelocyPack String's
+//	[]interface{}, for VelocyPack Array's
+//	map[string]interface{}, for VelocyPack Object's
+//	nil for VelocyPack Null.
+//  []byte for VelocyPack Binary.
+//
+// To unmarshal a VelocyPack array into a slice, Unmarshal resets the slice length
+// to zero and then appends each element to the slice.
+// As a special case, to unmarshal an empty VelocyPack array into a slice,
+// Unmarshal replaces the slice with a new empty slice.
+//
+// To unmarshal a VelocyPack array into a Go array, Unmarshal decodes
+// VelocyPack array elements into corresponding Go array elements.
+// If the Go array is smaller than the VelocyPack array,
+// the additional VelocyPack array elements are discarded.
+// If the VelocyPack array is smaller than the Go array,
+// the additional Go array elements are set to zero values.
+//
+// To unmarshal a VelocyPack object into a map, Unmarshal first establishes a map to
+// use. If the map is nil, Unmarshal allocates a new map. Otherwise Unmarshal
+// reuses the existing map, keeping existing entries. Unmarshal then stores
+// key-value pairs from the VelocyPack object into the map. The map's key type must
+// either be a string, an integer, or implement encoding.TextUnmarshaler.
+//
+// If a VelocyPack value is not appropriate for a given target type,
+// or if a VelocyPack number overflows the target type, Unmarshal
+// skips that field and completes the unmarshaling as best it can.
+// If no more serious errors are encountered, Unmarshal returns
+// an UnmarshalTypeError describing the earliest such error.
+//
+// The VelocyPack Null value unmarshals into an interface, map, pointer, or slice
+// by setting that Go value to nil. Because null is often used in VelocyPack to mean
+// ``not present,'' unmarshaling a VelocyPack Null into any other Go type has no effect
+// on the value and produces no error.
+//
 func Unmarshal(data []byte, v interface{}) error {
 	s := Slice(data)
 	if err := unmarshalSlice(s, v); err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -60,7 +60,11 @@ func NewEncoder(w io.Writer) *Encoder {
 // Marshal traverses the value v recursively.
 // If an encountered value implements the Marshaler interface
 // and is not a nil pointer, Marshal calls its MarshalVPack method
-// to produce Velocypack. If no MarshalVPack method is present but the
+// to produce Velocypack.
+// If an encountered value implements the json.Marshaler interface
+// and is not a nil pointer, Marshal calls its MarshalJSON method
+// to produce JSON and converts the resulting JSON to VelocyPack.
+// If no MarshalVPack or MarshalJSON method is present but the
 // value implements encoding.TextMarshaler instead, Marshal calls
 // its MarshalText method and encodes the result as a Velocypack string.
 // The nil pointer exception is not strictly necessary

--- a/encoder.go
+++ b/encoder.go
@@ -26,7 +26,9 @@
 package velocypack
 
 import (
+	"bytes"
 	"encoding"
+	"encoding/json"
 	"io"
 	"reflect"
 	"runtime"
@@ -174,6 +176,7 @@ func valueEncoder(v reflect.Value) encoderFunc {
 
 var (
 	marshalerType     = reflect.TypeOf(new(Marshaler)).Elem()
+	jsonMarshalerType = reflect.TypeOf(new(json.Marshaler)).Elem()
 	textMarshalerType = reflect.TypeOf(new(encoding.TextMarshaler)).Elem()
 	nullValue         = NewNullValue()
 )
@@ -218,9 +221,15 @@ func newTypeEncoder(t reflect.Type, allowAddr bool) encoderFunc {
 	if t.Implements(marshalerType) {
 		return marshalerEncoder
 	}
+	if t.Implements(jsonMarshalerType) {
+		return jsonMarshalerEncoder
+	}
 	if t.Kind() != reflect.Ptr && allowAddr {
 		if reflect.PtrTo(t).Implements(marshalerType) {
 			return newCondAddrEncoder(addrMarshalerEncoder, newTypeEncoder(t, false))
+		}
+		if reflect.PtrTo(t).Implements(jsonMarshalerType) {
+			return newCondAddrEncoder(addrJSONMarshalerEncoder, newTypeEncoder(t, false))
 		}
 	}
 
@@ -275,12 +284,32 @@ func marshalerEncoder(b *Builder, v reflect.Value) {
 		b.addInternal(nullValue)
 		return
 	}
-	vpack, err := m.MarshalVPack()
-	if err == nil {
+	if vpack, err := m.MarshalVPack(); err != nil {
+		panic(&MarshalerError{v.Type(), err})
+	} else {
 		b.addInternal(NewSliceValue(vpack))
 	}
-	if err != nil {
+}
+
+func jsonMarshalerEncoder(b *Builder, v reflect.Value) {
+	if v.Kind() == reflect.Ptr && v.IsNil() {
+		b.addInternal(nullValue)
+		return
+	}
+	m, ok := v.Interface().(json.Marshaler)
+	if !ok {
+		b.addInternal(nullValue)
+		return
+	}
+	if json, err := m.MarshalJSON(); err != nil {
 		panic(&MarshalerError{v.Type(), err})
+	} else {
+		// Convert JSON to vpack
+		if slice, err := ParseJSON(bytes.NewReader(json)); err != nil {
+			panic(&MarshalerError{v.Type(), err})
+		} else {
+			b.addInternal(NewSliceValue(slice))
+		}
 	}
 }
 
@@ -291,13 +320,30 @@ func addrMarshalerEncoder(b *Builder, v reflect.Value) {
 		return
 	}
 	m := va.Interface().(Marshaler)
-	vpack, err := m.MarshalVPack()
-	if err == nil {
-		// copy JSON into buffer, checking validity.
+	if vpack, err := m.MarshalVPack(); err != nil {
+		panic(&MarshalerError{Type: v.Type(), Err: err})
+	} else {
+		// copy VPack into buffer, checking validity.
 		b.buf.Write(vpack)
 	}
-	if err != nil {
+}
+
+func addrJSONMarshalerEncoder(b *Builder, v reflect.Value) {
+	va := v.Addr()
+	if va.IsNil() {
+		b.addInternal(nullValue)
+		return
+	}
+	m := va.Interface().(json.Marshaler)
+	if json, err := m.MarshalJSON(); err != nil {
 		panic(&MarshalerError{Type: v.Type(), Err: err})
+	} else {
+		if slice, err := ParseJSON(bytes.NewReader(json)); err != nil {
+			panic(&MarshalerError{v.Type(), err})
+		} else {
+			// copy VPack into buffer, checking validity.
+			b.buf.Write(slice)
+		}
 	}
 }
 
@@ -477,7 +523,7 @@ func newSliceEncoder(t reflect.Type) encoderFunc {
 	// Byte slices get special treatment; arrays don't.
 	if t.Elem().Kind() == reflect.Uint8 {
 		p := reflect.PtrTo(t.Elem())
-		if !p.Implements(marshalerType) && !p.Implements(textMarshalerType) {
+		if !p.Implements(marshalerType) && !p.Implements(jsonMarshalerType) && !p.Implements(textMarshalerType) {
 			return encodeByteSlice
 		}
 	}

--- a/test/decoder_custom_test.go
+++ b/test/decoder_custom_test.go
@@ -174,3 +174,45 @@ func TestDecoderCustomJSONStruct1(t *testing.T) {
 	ASSERT_NIL(err, t)
 	ASSERT_EQ(v, expected, t)
 }
+
+func (cs *CustomJSONVPACKStruct1) UnmarshalVPack(slice velocypack.Slice) error {
+	s, err := slice.GetString()
+	if err != nil {
+		return err
+	}
+	if s != "Hello VPACK, goodbye JSON" {
+		return fmt.Errorf("Expected 'Hello VPACK, goodbye JSON' got '%s'", s)
+	}
+	cs.Field1 = 99
+	return nil
+}
+
+func (cs *CustomJSONVPACKStruct1) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s != "Hello JSON, goodbye VPACK" {
+		return fmt.Errorf("Expected 'Hello JSON, goodbye VPACK' got '%s'", s)
+	}
+	cs.Field1 = 88
+	return nil
+}
+
+func TestDecoderCustomJSONVPACKStruct1(t *testing.T) {
+	// UnmarshalVPack is preferred over UnmarshalJSON
+	input := &CustomJSONVPACKStruct1{
+		Field1: 999,
+	}
+	bytes, err := velocypack.Marshal(input)
+	ASSERT_NIL(err, t)
+	s := velocypack.Slice(bytes)
+	expected := CustomJSONVPACKStruct1{
+		Field1: 99,
+	}
+
+	var v CustomJSONVPACKStruct1
+	err = velocypack.Unmarshal(s, &v)
+	ASSERT_NIL(err, t)
+	ASSERT_EQ(v, expected, t)
+}

--- a/test/decoder_custom_test.go
+++ b/test/decoder_custom_test.go
@@ -23,6 +23,7 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -140,6 +141,35 @@ func TestDecoderCustomText1(t *testing.T) {
 	s := velocypack.Slice(bytes)
 
 	var v map[CustomText1]bool
+	err = velocypack.Unmarshal(s, &v)
+	ASSERT_NIL(err, t)
+	ASSERT_EQ(v, expected, t)
+}
+
+func (cs *CustomJSONStruct1) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	if s != "Hello JSON" {
+		return fmt.Errorf("Expected 'Hello JSON' got '%s'", s)
+	}
+	cs.Field1 = 88
+	return nil
+}
+
+func TestDecoderCustomJSONStruct1(t *testing.T) {
+	input := &CustomJSONStruct1{
+		Field1: 999,
+	}
+	bytes, err := velocypack.Marshal(input)
+	ASSERT_NIL(err, t)
+	s := velocypack.Slice(bytes)
+	expected := CustomJSONStruct1{
+		Field1: 88,
+	}
+
+	var v CustomJSONStruct1
 	err = velocypack.Unmarshal(s, &v)
 	ASSERT_NIL(err, t)
 	ASSERT_EQ(v, expected, t)

--- a/test/encoder_custom_test.go
+++ b/test/encoder_custom_test.go
@@ -23,6 +23,7 @@
 package test
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -105,4 +106,23 @@ func TestEncoderCustomText1(t *testing.T) {
 
 	ASSERT_EQ(s.Type(), velocypack.Object, t)
 	ASSERT_EQ(`{"key2":false,"key7":true}`, mustString(s.JSONString()), t)
+}
+
+type CustomJSONStruct1 struct {
+	Field1 int
+}
+
+func (cs *CustomJSONStruct1) MarshalJSON() ([]byte, error) {
+	return json.Marshal("Hello JSON")
+}
+
+func TestEncoderCustomJSONStruct1(t *testing.T) {
+	bytes, err := velocypack.Marshal(&CustomJSONStruct1{
+		Field1: 999,
+	})
+	ASSERT_NIL(err, t)
+	s := velocypack.Slice(bytes)
+
+	ASSERT_EQ(s.Type(), velocypack.String, t)
+	ASSERT_EQ(`"Hello JSON"`, mustString(s.JSONString()), t)
 }

--- a/test/encoder_custom_test.go
+++ b/test/encoder_custom_test.go
@@ -126,3 +126,31 @@ func TestEncoderCustomJSONStruct1(t *testing.T) {
 	ASSERT_EQ(s.Type(), velocypack.String, t)
 	ASSERT_EQ(`"Hello JSON"`, mustString(s.JSONString()), t)
 }
+
+type CustomJSONVPACKStruct1 struct {
+	Field1 int
+}
+
+func (cs *CustomJSONVPACKStruct1) MarshalVPack() (velocypack.Slice, error) {
+	var b velocypack.Builder
+	if err := b.AddValue(velocypack.NewStringValue("Hello VPACK, goodbye JSON")); err != nil {
+		return nil, err
+	}
+	return b.Slice()
+}
+
+func (cs *CustomJSONVPACKStruct1) MarshalJSON() ([]byte, error) {
+	return json.Marshal("Hello JSON, goodbye VPACK")
+}
+
+func TestEncoderCustomJSONVPACKStruct1(t *testing.T) {
+	// MarshalVPack is preferred over MarshalJSON
+	bytes, err := velocypack.Marshal(&CustomJSONVPACKStruct1{
+		Field1: 999,
+	})
+	ASSERT_NIL(err, t)
+	s := velocypack.Slice(bytes)
+
+	ASSERT_EQ(s.Type(), velocypack.String, t)
+	ASSERT_EQ(`"Hello VPACK, goodbye JSON"`, mustString(s.JSONString()), t)
+}


### PR DESCRIPTION
This PR adds support to the encoder/decoder for types that implement json.Marshaler/json.Unmarshaler.

Note that when types implement both velocypack.(Un)Marshaler and json.(Un)Marshaler, only the (Un)MarshalVPack function will be used.