### PR TITLE
Fix marshaling custom structures

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -336,8 +336,9 @@ func addrMarshalerEncoder(b *Builder, v reflect.Value, options encoderOptions) {
 	if vpack, err := m.MarshalVPack(); err != nil {
 		panic(&MarshalerError{Type: v.Type(), Err: err})
 	} else {
-		// copy VPack into buffer, checking validity.
-		b.buf.Write(vpack)
+		if err = b.AddValue(NewSliceValue(vpack)); err != nil {
+			panic(&MarshalerError{Type: v.Type(), Err: err})
+		}
 	}
 }
 

--- a/encoder_field.go
+++ b/encoder_field.go
@@ -153,10 +153,16 @@ func typeFields(t reflect.Type) []field {
 				if sf.PkgPath != "" && !sf.Anonymous { // unexported
 					continue
 				}
-				tag := sf.Tag.Get("json")
+
+				tag := sf.Tag.Get("velocypack")
+				if len(tag) == 0 {
+					tag = sf.Tag.Get("json")
+				}
+
 				if tag == "-" {
 					continue
 				}
+
 				name, opts := parseTag(tag)
 				if !isValidTag(name) {
 					name = ""
@@ -173,7 +179,7 @@ func typeFields(t reflect.Type) []field {
 
 				// Only strings, floats, integers, and booleans can be quoted.
 				quoted := false
-				if opts.Contains("string") {
+				if opts.Contains("string") && !opts.Contains("noquota") {
 					switch ft.Kind() {
 					case reflect.Bool,
 						reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,

--- a/encoder_field.go
+++ b/encoder_field.go
@@ -179,7 +179,7 @@ func typeFields(t reflect.Type) []field {
 
 				// Only strings, floats, integers, and booleans can be quoted.
 				quoted := false
-				if opts.Contains("string") && !opts.Contains("noquote") {
+				if opts.Contains("string") {
 					switch ft.Kind() {
 					case reflect.Bool,
 						reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,

--- a/encoder_field.go
+++ b/encoder_field.go
@@ -179,7 +179,7 @@ func typeFields(t reflect.Type) []field {
 
 				// Only strings, floats, integers, and booleans can be quoted.
 				quoted := false
-				if opts.Contains("string") && !opts.Contains("noquota") {
+				if opts.Contains("string") && !opts.Contains("noquote") {
 					switch ft.Kind() {
 					case reflect.Bool,
 						reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/arangodb/go-velocypack
 
 go 1.12
 
-require github.com/stretchr/testify v1.3.0
+require github.com/stretchr/testify v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -3,5 +3,9 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
-github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/test/encoder_custom_test.go
+++ b/test/encoder_custom_test.go
@@ -25,6 +25,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"strconv"
 	"strings"
 	"testing"
@@ -302,9 +303,12 @@ func (c *ConnectionString) MarshalVPack() (velocypack.Slice, error) {
 }
 
 type CustomStructConnectionString struct {
-	ConnectionString ConnectionString `json:"connectionString,string" velocypack:"connectionString"`
+	ConnectionString ConnectionString `json:"invalidString,string" velocypack:"connectionString"`
 }
 
+// TestEncoderCustomStructConnectionString tests two things:
+// - Using 'velocypack' tag instead of 'json' tag
+// - Marshaling structure field which is not a pointer
 func TestEncoderCustomStructConnectionString(t *testing.T) {
 
 	expected := CustomStructConnectionString{
@@ -315,10 +319,12 @@ func TestEncoderCustomStructConnectionString(t *testing.T) {
 	}
 
 	marshaledStructure, err := velocypack.Marshal(&expected)
-	ASSERT_NIL(err, t)
+	require.NoError(t, err)
+	require.Contains(t, string(marshaledStructure), "connectionString")
 
 	actual := CustomStructConnectionString{}
 	err = velocypack.Unmarshal(marshaledStructure, &actual)
-	ASSERT_NIL(err, t)
-	ASSERT_EQ(expected, actual, t)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+
 }

--- a/test/encoder_custom_test.go
+++ b/test/encoder_custom_test.go
@@ -25,6 +25,7 @@ package test
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"strconv"
 	"strings"
@@ -319,12 +320,11 @@ func TestEncoderCustomStructConnectionString(t *testing.T) {
 	}
 
 	marshaledStructure, err := velocypack.Marshal(&expected)
-	require.NoError(t, err)
-	require.Contains(t, string(marshaledStructure), "connectionString")
+	require.Error(t, err)
+	assert.Contains(t, string(marshaledStructure), "connectionString")
 
 	actual := CustomStructConnectionString{}
 	err = velocypack.Unmarshal(marshaledStructure, &actual)
 	require.NoError(t, err)
-	require.Equal(t, expected, actual)
-
+	assert.Equal(t, expected, actual)
 }

--- a/test/encoder_custom_test.go
+++ b/test/encoder_custom_test.go
@@ -320,7 +320,7 @@ func TestEncoderCustomStructConnectionString(t *testing.T) {
 	}
 
 	marshaledStructure, err := velocypack.Marshal(&expected)
-	require.Error(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(marshaledStructure), "connectionString")
 
 	actual := CustomStructConnectionString{}


### PR DESCRIPTION
1) Fix issue with Marshal custom fields in the structure.

2) 
Add tag "velocypack" for the field of the structure. It gives us the possibility to marshal and unmarshal different types. E. g:

```
type RevisionTree struct {
	Version  int                `json:"version"`
	RangeMin RevisionInt64      `json:"rangeMin,string" velocypack:"rangeMin"`
	RangeMax RevisionInt64      `json:"rangeMax,string" velocypack:"rangeMax"`
	Nodes    []RevisionTreeNode `json:"nodes"`
}
```
We can Marsjal from int64 to string and Unmarshal from string to int64.
I need that in go-driver to build MerkleTree.
In the future, we should not use 'json' tag for velocypack data format and maybe we will change that someday but of course there is a backward compatibility so if there is not 'velocypack' tag then we use 'json' tag.


